### PR TITLE
corrected filename parsing for artifacts when running on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## neptune-sacred 0.9.7 [UNRELEASED]
+
+### Fixes
+- Corrected filename parsing for artifacts when running on Windows ([#9](https://github.com/neptune-ai/neptune-sacred/pull/9))
+
 ## neptune-sacred 0.9.6
 
 ### Features

--- a/neptune_sacred/impl/__init__.py
+++ b/neptune_sacred/impl/__init__.py
@@ -15,6 +15,7 @@
 #
 
 import warnings
+import os
 
 from sacred.dependencies import get_digest
 from sacred.observers import RunObserver
@@ -126,7 +127,7 @@ class NeptuneObserver(RunObserver):
         pass
 
     def artifact_event(self, name, filename, metadata=None, content_type=None):
-        filename = filename.rsplit('/', 1)[-1]
+        filename = os.path.split(filename)[-1]
         self._run[self.base_namespace][f'io_files/artifacts/{filename}'].upload(name)
 
     def resource_event(self, filename):


### PR DESCRIPTION
This PR corrects the incorrect artifact file name problem mentioned in issue #5.

I tested this change locally in both Windows and Linux environments to confirm that the file name is being correctly extracted from the absolute file path.