### PR TITLE
Added the ability to log artifacts under a different name than the or…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## neptune-sacred 0.9.7 [UNRELEASED]
 
 ### Fixes
-- Added the ability to log artifacts under a different name than the original filename ([#9](https://github.com/neptune-ai/neptune-sacred/pull/9))
+- Added the ability to log artifacts under a different name than the original filename ([#10](https://github.com/neptune-ai/neptune-sacred/pull/10))
 
 ## neptune-sacred 0.9.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## neptune-sacred 0.9.7 [UNRELEASED]
+
+### Fixes
+- Added the ability to log artifacts under a different name than the original filename ([#9](https://github.com/neptune-ai/neptune-sacred/pull/9))
+
 ## neptune-sacred 0.9.6
 
 ### Features

--- a/neptune_sacred/impl/__init__.py
+++ b/neptune_sacred/impl/__init__.py
@@ -127,7 +127,7 @@ class NeptuneObserver(RunObserver):
 
     def artifact_event(self, name, filename, metadata=None, content_type=None):
         filename = filename.rsplit('/', 1)[-1]
-        self._run[self.base_namespace][f'io_files/artifacts/{filename}'].upload(name)
+        self._run[self.base_namespace][f'io_files/artifacts/{name}'].upload(filename)
 
     def resource_event(self, filename):
         if filename not in self.resources:


### PR DESCRIPTION
…iginal filename

This change addresses the feature request in issue #7, which is something that the `FileStorageObserver` and `S3Observer` from `sacred.observers` can already do.