### PR TITLE
Convert result lists/dictionaries to JSON strings so that they can b…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## neptune-sacred 0.9.7 [UNRELEASED]
+
+### Fixes
+- Convert result lists/dictionaries to JSON strings so that they can be logged as metrics ([#11](https://github.com/neptune-ai/neptune-sacred/pull/11))
+
 ## neptune-sacred 0.9.6
 
 ### Features

--- a/neptune_sacred/impl/__init__.py
+++ b/neptune_sacred/impl/__init__.py
@@ -15,6 +15,7 @@
 #
 
 import warnings
+import json
 
 from sacred.dependencies import get_digest
 from sacred.observers import RunObserver
@@ -113,6 +114,8 @@ class NeptuneObserver(RunObserver):
                     self._run[self.base_namespace][f'metrics/results/{k}'] = v
                 elif isinstance(v, int) or isinstance(v, float):
                     self._run[self.base_namespace][f'metrics/results/{k}'] = float(v)
+                elif isinstance(v, list) or isinstance(v, dict):
+                    self._run[self.base_namespace][f'metrics/results/{k}'] = json.dumps(v)
                 elif isinstance(v, object):
                     self._run[self.base_namespace][f'metrics/results/{k}'].upload(v)
                 else:


### PR DESCRIPTION
…e logged as metrics

This PR implements the feature request (possibly a bug?) introduced in #8 and allows for `sacred` experiment results that are lists and dictionaries to be logged to Neptune by converting them into JSON strings using `json.dumps()`. Otherwise, lists/dictionaries are treated as objects to be uploaded using the `.upload()` method, which raises this error:

`TypeError: Value of type <class 'dict'> is not supported.`

Representing lists/dictionaries as JSON/strings is how the `FileStorageObserver` and `S3Observer` from `sacred.observers`  handles this type of result. In addition, `SlackObserver` also uses `json.dumps()` in order to transmit experiment results as a Slack messages.